### PR TITLE
Add in Rerun graph viz

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,15 +133,16 @@ checksum = "bf7d0a018de4f6aa429b9d33d69edf69072b1c5b1cb8d3e4a5f7ef898fc3eb76"
 
 [[package]]
 name = "arrow"
-version = "53.3.0"
+version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91839b07e474b3995035fd8ac33ee54f9c9ccbbb1ea33d9909c71bffdf1259d"
+checksum = "eaf3437355979f1e93ba84ba108c38be5767713051f3c8ffbf07c094e2e61f9f"
 dependencies = [
  "arrow-arith",
  "arrow-array",
  "arrow-buffer",
  "arrow-cast",
  "arrow-data",
+ "arrow-ipc",
  "arrow-ord",
  "arrow-row",
  "arrow-schema",
@@ -151,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "53.3.0"
+version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "855c57c4efd26722b044dcd3e348252560e3e0333087fb9f6479dc0bf744054f"
+checksum = "31dce77d2985522288edae7206bffd5fc4996491841dda01a13a58415867e681"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -166,9 +167,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "53.3.0"
+version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd03279cea46569acf9295f6224fbc370c5df184b4d2ecfe97ccb131d5615a7f"
+checksum = "2d45fe6d3faed0435b7313e59a02583b14c6c6339fa7729e94c32a20af319a79"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -182,9 +183,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "53.3.0"
+version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e4a9b9b1d6d7117f6138e13bc4dd5daa7f94e671b70e8c9c4dc37b4f5ecfc16"
+checksum = "2b02656a35cc103f28084bc80a0159668e0a680d919cef127bd7e0aaccb06ec1"
 dependencies = [
  "bytes",
  "half",
@@ -193,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "53.3.0"
+version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc70e39916e60c5b7af7a8e2719e3ae589326039e1e863675a008bee5ffe90fd"
+checksum = "c73c6233c5b5d635a56f6010e6eb1ab9e30e94707db21cea03da317f67d84cf3"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -213,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "53.3.0"
+version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4e75edf21ffd53744a9b8e3ed11101f610e7ceb1a29860432824f1834a1f623"
+checksum = "b7f2861ffa86f107b8ab577d86cff7c7a490243eabe961ba1e1af4f27542bb79"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -234,10 +235,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-ord"
-version = "53.3.0"
+name = "arrow-ipc"
+version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece7b5bc1180e6d82d1a60e1688c199829e8842e38497563c3ab6ea813e527fd"
+checksum = "0270dc511f11bb5fa98a25020ad51a99ca5b08d8a8dfbd17503bb9dba0388f0b"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "53.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f202a879d287099139ff0d121e7f55ae5e0efe634b8cf2106ebc27a8715dee"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -250,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "53.3.0"
+version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "745c114c8f0e8ce211c83389270de6fbe96a9088a7b32c2a041258a443fe83ff"
+checksum = "a8f936954991c360ba762dff23f5dda16300774fafd722353d9683abd97630ae"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -264,15 +279,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "53.3.0"
+version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95513080e728e4cec37f1ff5af4f12c9688d47795d17cda80b6ec2cf74d4678"
+checksum = "9579b9d8bce47aa41389fe344f2c6758279983b7c0ebb4013e283e3e91bb450e"
 
 [[package]]
 name = "arrow-select"
-version = "53.3.0"
+version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e415279094ea70323c032c6e739c48ad8d80e78a09bef7117b8718ad5bf3722"
+checksum = "7471ba126d0b0aaa24b50a36bc6c25e4e74869a1fd1a5553357027a0b1c8d1f1"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -284,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "53.3.0"
+version = "53.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11d956cae7002eb8d83a27dbd34daaea1cf5b75852f0b84deb4d93a276e92bbf"
+checksum = "72993b01cb62507b06f1fb49648d7286c8989ecfabdb7b77a750fcb54410731b"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -953,9 +968,9 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "emath"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4fe73c1207b864ee40aa0b0c038d6092af1030744678c60188a05c28553515d"
+checksum = "55b7b6be5ad1d247f11738b0e4699d9c20005ed366f2c29f5ec1f8e1de180bc2"
 
 [[package]]
 name = "encode_unicode"
@@ -1205,9 +1220,9 @@ dependencies = [
 
 [[package]]
 name = "flatbuffers"
-version = "23.5.26"
+version = "24.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dac53e22462d78c16d64a1cd22371b54cc3fe94aa15e7886a2fa6e5d1ab8640"
+checksum = "4f1baf0dbf96932ec9a3038d57900329c015b0bfb7b63d904f3bc27e2b02a096"
 dependencies = [
  "bitflags 1.3.2",
  "rustc_version",
@@ -1737,9 +1752,9 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2609,9 +2624,9 @@ dependencies = [
 
 [[package]]
 name = "re_arrow2"
-version = "0.18.1"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad04cc9064504e653c6a6de42a45982bbe899e61657164072eca7e3ab6de1e9f"
+checksum = "6973c87de24c9de7292447fa896f229278b010cb3fb5e7f4f857447e64e1bb6f"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -2621,7 +2636,6 @@ dependencies = [
  "arrow-schema",
  "bytemuck",
  "chrono",
- "comfy-table",
  "dyn-clone",
  "either",
  "ethnum",
@@ -2636,19 +2650,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "re_build_info"
-version = "0.21.0"
+name = "re_arrow_util"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b88b413ebeee91520b7825e4fde0b65702394f5282f5e783e56d0d8155a536a"
+checksum = "53e5a9c65130a285afabd6d260ab28772e777c80b13f1ad9690e7f88a470656f"
 dependencies = [
+ "arrow",
+ "itertools 0.13.0",
+ "re_log",
+ "re_tracing",
+]
+
+[[package]]
+name = "re_build_info"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ababe5a4dce6ac9e54383c3b1216955cef057007dae59e6e798df288dc22e1f"
+dependencies = [
+ "re_byte_size",
  "serde",
 ]
 
 [[package]]
 name = "re_build_tools"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0892c63699ce6d5a87a8b18a8b2ab587124aa32fee251c1107fab44ca4e4c786"
+checksum = "199aff40cfb4d25f54ceadb3fbd626d5ddaaa35832d2644e76457fd79a3b0d8e"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.18.1",
@@ -2660,10 +2687,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "re_capabilities"
-version = "0.21.0"
+name = "re_byte_size"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff19bd8c1f2604f4207847a80b1ffebe1654a24f422872b60e873e28b369462"
+checksum = "87a3cca3e568c4347be3de3079a52511b885d585459492a68631c22b99554c50"
+dependencies = [
+ "arrow",
+ "half",
+ "smallvec",
+]
+
+[[package]]
+name = "re_capabilities"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27a4cab51938416ab4e6ec45f489f7b917a13b23eed93bb40510492d7a06fef8"
 dependencies = [
  "document-features",
  "static_assertions",
@@ -2671,18 +2709,18 @@ dependencies = [
 
 [[package]]
 name = "re_case"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dce93a41adb3c620e2b03c1c995eb9ba57e520143ef7ee4d8b4f7e53514a36"
+checksum = "0de349d99205dda90c3ac937eb6f63e3f206aea4d794377a2f4aecded32768af"
 dependencies = [
  "convert_case",
 ]
 
 [[package]]
 name = "re_chunk"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a0cc5e3e6c262b0c3b9babad886e30af36ca041da64121afbe68c6341e6d924"
+checksum = "45a65597e34899c3467e36debb0f63ab31b72bc97cf82885f539369db4862cc5"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2690,10 +2728,12 @@ dependencies = [
  "bytemuck",
  "crossbeam",
  "document-features",
+ "half",
  "itertools 0.13.0",
  "nohash-hasher",
  "rand",
- "re_arrow2",
+ "re_arrow_util",
+ "re_byte_size",
  "re_error",
  "re_format",
  "re_format_arrow",
@@ -2702,32 +2742,35 @@ dependencies = [
  "re_tracing",
  "re_tuid",
  "re_types_core",
- "serde",
  "similar-asserts",
+ "tap",
  "thiserror",
 ]
 
 [[package]]
 name = "re_chunk_store"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9468c4409588cba5cad103fe5205a922294ada40989cbbc13fd83a1ac982c932"
+checksum = "771083f86c1899d8251cd8cc8cfa85a8da72f21704499017821fb0794d63df86"
 dependencies = [
  "ahash",
  "anyhow",
+ "arrow",
  "document-features",
  "indent",
  "itertools 0.13.0",
  "nohash-hasher",
  "once_cell",
  "parking_lot",
- "re_arrow2",
+ "re_arrow_util",
+ "re_byte_size",
  "re_chunk",
  "re_format",
  "re_log",
  "re_log_encoding",
  "re_log_types",
  "re_protos",
+ "re_sorbet",
  "re_tracing",
  "re_types_core",
  "thiserror",
@@ -2736,9 +2779,9 @@ dependencies = [
 
 [[package]]
 name = "re_crash_handler"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bdf77e0a0c1310fa5c02b9d66e33b73693bbd61d44a93bcb3d58cae8a34156"
+checksum = "584bdf3f0bef37cbb110426aed15fc916b11bb6c31f3e33eaa3a5af38588c671"
 dependencies = [
  "backtrace",
  "econtext",
@@ -2750,9 +2793,9 @@ dependencies = [
 
 [[package]]
 name = "re_entity_db"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eec319df6d68a71390aae382ae2982915c95ab3fa69bd286104e6954b46d8986"
+checksum = "bd5c275f13935dcbd3b294f8bcbf1cae392c6517fd70ed43ec7dca24ae3b3299"
 dependencies = [
  "ahash",
  "document-features",
@@ -2761,6 +2804,7 @@ dependencies = [
  "nohash-hasher",
  "parking_lot",
  "re_build_info",
+ "re_byte_size",
  "re_chunk",
  "re_chunk_store",
  "re_format",
@@ -2778,36 +2822,38 @@ dependencies = [
 
 [[package]]
 name = "re_error"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0adebf7ffebab798e5171717bc99f228619cdf8bb9a79806346f3c41ef7a0f3"
+checksum = "baeb51e70c152696f94b099d9898ea836e72b068bc3883340b333df4577c1aaf"
 
 [[package]]
 name = "re_format"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01706f49ef1e074aca58c7161280057f74ff181199c558146585b58f23c0ecd"
+checksum = "12f71a2dd1cd3983c087a9b7690f271edb463532172981987b77c86c521d9e98"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "re_format_arrow"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f318b5363e4d798b08f2fa0c0135f0fd137136100000a06adae235ba368344f"
+checksum = "e3401e90f499202df7ca8a80bedc30435c5d2b82bcd6e79b7234b27e7816c016"
 dependencies = [
+ "arrow",
  "comfy-table",
- "re_arrow2",
+ "itertools 0.13.0",
+ "re_arrow_util",
  "re_tuid",
  "re_types_core",
 ]
 
 [[package]]
 name = "re_int_histogram"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1fc768a59b0ffd7178cf592d6290f48346ade4adb930862f2c7d83ded2d32"
+checksum = "c7daf10c205a2c3af44d24c856d417925751be220d2d5c36cc3b92f6bc4c20c6"
 dependencies = [
  "smallvec",
  "static_assertions",
@@ -2815,9 +2861,9 @@ dependencies = [
 
 [[package]]
 name = "re_log"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd546fa37286a0114641cf7b271eca4bce3b4a20041ca378fb3530b8dc947b8"
+checksum = "be8a07923f0227e54f506181110e52f5b3e9b2a8327ba27df90bd387b4d851d8"
 dependencies = [
  "env_logger",
  "js-sys",
@@ -2830,10 +2876,12 @@ dependencies = [
 
 [[package]]
 name = "re_log_encoding"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6ddf1fbcb460622f305711563047d1f04ca248f0dca046dbba19b4b6df51424"
+checksum = "7e381b54191aaab469501a39908da84f118150d1dfd4027e34bb43b6fbd7af97"
 dependencies = [
+ "arrow",
+ "bytes",
  "lz4_flex",
  "parking_lot",
  "re_arrow2",
@@ -2846,16 +2894,19 @@ dependencies = [
  "re_tracing",
  "rmp-serde",
  "thiserror",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
 name = "re_log_types"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a48047201720a8d950910b2d90471d36b05a4fc581d3b4c4ec1856c939d9a39"
+checksum = "593ce0f20b522b49f7af9111f6117d07b0fc99437e416f86d69f8b39f464e512"
 dependencies = [
  "ahash",
  "anyhow",
+ "arrow",
  "backtrace",
  "bytemuck",
  "clean-path",
@@ -2868,10 +2919,11 @@ dependencies = [
  "num-derive",
  "num-traits",
  "re_arrow2",
+ "re_arrow_util",
  "re_build_info",
+ "re_byte_size",
  "re_format",
  "re_log",
- "re_protos",
  "re_string_interner",
  "re_tracing",
  "re_tuid",
@@ -2888,9 +2940,9 @@ dependencies = [
 
 [[package]]
 name = "re_memory"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec4106e54dde4835fc601458283c02a783f8fa5bfd5b010c74e7bf251c3bf83e"
+checksum = "3f2064e1fc2aa66df7698cb10b058724ee8281d7641db09e649d1d1ea08601ff"
 dependencies = [
  "ahash",
  "backtrace",
@@ -2925,11 +2977,17 @@ dependencies = [
 
 [[package]]
 name = "re_protos"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95f75d9831745a5944ef6a338cc3cc06f8d39a83506f943896eaf602ab1166c4"
+checksum = "7d3731719bf29d23b0922813f3cfeaf00eda303dfaa47821065a225b1a07b884"
 dependencies = [
+ "arrow",
  "prost",
+ "re_build_info",
+ "re_byte_size",
+ "re_log_types",
+ "re_sorbet",
+ "re_tuid",
  "thiserror",
  "tonic",
  "tonic-web-wasm-client",
@@ -2937,19 +2995,21 @@ dependencies = [
 
 [[package]]
 name = "re_query"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9c7b7cd2bcd4ee1f2bdfaba50f10af72baca0ac44fb7865618f7108cd0e7f7b"
+checksum = "24fd2cfa139497fc8a3ca08fdaf5f7e2a639bc9e271b87cb4fe518d130bf9735"
 dependencies = [
  "ahash",
  "anyhow",
+ "arrow",
  "backtrace",
  "indent",
  "itertools 0.13.0",
  "nohash-hasher",
  "parking_lot",
  "paste",
- "re_arrow2",
+ "re_arrow_util",
+ "re_byte_size",
  "re_chunk",
  "re_chunk_store",
  "re_error",
@@ -2964,9 +3024,9 @@ dependencies = [
 
 [[package]]
 name = "re_sdk"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c3b408455022a5cbbfe3a36e0006eb87c07b3b63dd55f14ff01cfe0e7de902f"
+checksum = "136f1b37fb360b7e23d8ff95b0c13964419c8d4c95ace609ee6a34a243b29ff2"
 dependencies = [
  "ahash",
  "crossbeam",
@@ -2976,9 +3036,9 @@ dependencies = [
  "nohash-hasher",
  "once_cell",
  "parking_lot",
- "re_arrow2",
  "re_build_info",
  "re_build_tools",
+ "re_byte_size",
  "re_chunk",
  "re_log",
  "re_log_encoding",
@@ -2991,9 +3051,9 @@ dependencies = [
 
 [[package]]
 name = "re_sdk_comms"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2eb73d054d2bea611e6eb5c8aba1e1b25010a46c834cbc545a9855dd9c0a8"
+checksum = "0f029e203331dafdf0882b26ca8548f5a290116db45c8b19caa309e6107d9480"
 dependencies = [
  "ahash",
  "crossbeam",
@@ -3008,9 +3068,9 @@ dependencies = [
 
 [[package]]
 name = "re_smart_channel"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7d07784b8939f05364f526590fc7aa3d3a43797f31db0a0492a279046f7d690"
+checksum = "88328d8752d0c3a73c3b25947e45a3e0b1b48c798c70e1bde501d26164858b96"
 dependencies = [
  "crossbeam",
  "parking_lot",
@@ -3020,10 +3080,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "re_string_interner"
-version = "0.21.0"
+name = "re_sorbet"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10218faacf52f7453a6fda036d4418907e3465229e9ec32bf662c181e6b365c0"
+checksum = "3b7f361fb581b99145dd9d7a19d1f5859fa66fd54923ace3074a0b63f7a684ab"
+dependencies = [
+ "arrow",
+ "re_log",
+ "re_log_types",
+ "re_types_core",
+ "thiserror",
+]
+
+[[package]]
+name = "re_string_interner"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64360b8b434a72ea1087a2a90f1c2b3f638b401d22437eae9c616fa44a635f8d"
 dependencies = [
  "ahash",
  "nohash-hasher",
@@ -3035,32 +3108,32 @@ dependencies = [
 
 [[package]]
 name = "re_tracing"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6112ec08a39f169bdf843ffb318872c909038effde68e67e1b0b19ffa3f380c1"
+checksum = "d0bb55d18b9401b769ddab6ab88aca2b3d124ae7441c3b163eda829615c052a5"
 dependencies = [
  "puffin",
 ]
 
 [[package]]
 name = "re_tuid"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fab74c48f17a4a29b29e1184f690c4470f0f34126eedd5051868afc8e908af"
+checksum = "ab0df70fff54c1f54f7bd5545fdc5657f6d54fa5b9ccd888e28e72d7a4c36edd"
 dependencies = [
  "document-features",
  "getrandom",
  "once_cell",
- "re_protos",
+ "re_byte_size",
  "serde",
  "web-time",
 ]
 
 [[package]]
 name = "re_types"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8969f3feb653267d32b3a50272adebd2b36e874572a591e61fa1081418a49ec3"
+checksum = "cb54e2ab3b830a2bf5b046bf8cfe988232877ee24f8ae5bd4a9b6ddb15044c2d"
 dependencies = [
  "anyhow",
  "array-init",
@@ -3078,8 +3151,9 @@ dependencies = [
  "once_cell",
  "ply-rs",
  "rayon",
- "re_arrow2",
  "re_build_tools",
+ "re_byte_size",
+ "re_error",
  "re_format",
  "re_log",
  "re_log_types",
@@ -3093,9 +3167,9 @@ dependencies = [
 
 [[package]]
 name = "re_types_builder"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d9a754673bb2a1a08266d32797cf429394dca0bf80c5d13594d6d7d207f9e11"
+checksum = "4e70a48296d818032a5d48145f7ce2df527f5f483544046d3bcb48a7ab3873fc"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3126,9 +3200,9 @@ dependencies = [
 
 [[package]]
 name = "re_types_core"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ba9a0b66c99a435560675ff422da8e5ee9f42eaf6bf9daae75a0cc9a084573"
+checksum = "08b4d6ea5eb0c3d7fc7a7dcdb28271193cac539cc297f70ea68791537a3ed34f"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3139,22 +3213,23 @@ dependencies = [
  "itertools 0.13.0",
  "nohash-hasher",
  "once_cell",
- "re_arrow2",
+ "re_arrow_util",
+ "re_byte_size",
  "re_case",
  "re_error",
+ "re_log",
  "re_string_interner",
  "re_tracing",
  "re_tuid",
  "serde",
- "smallvec",
  "thiserror",
 ]
 
 [[package]]
 name = "re_video"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6626e79ef75582a27d3610ed777cfb12e928446dbccf5fec518a503e2c365e"
+checksum = "e128090fb57ae644aaa29a511d46ea44f24e7f87cd125087da38a1d074bc93c5"
 dependencies = [
  "bit-vec",
  "cfg_aliases",
@@ -3221,23 +3296,26 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rerun"
-version = "0.21.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "620b001ee2d8f6187e2c91ef2726379a29eb4d89c440aab8ed0bba886d9d4c83"
+checksum = "ee0a19185405072621c2e82866bb0a38ea3e703d79950f0789259d59e69831a0"
 dependencies = [
  "anyhow",
+ "arrow",
  "document-features",
  "itertools 0.13.0",
  "puffin",
  "rayon",
  "re_build_info",
  "re_build_tools",
+ "re_byte_size",
  "re_capabilities",
  "re_chunk",
  "re_crash_handler",
  "re_entity_db",
  "re_error",
  "re_format",
+ "re_format_arrow",
  "re_log",
  "re_log_encoding",
  "re_log_types",
@@ -3584,6 +3662,12 @@ dependencies = [
  "once_cell",
  "windows",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -4013,20 +4097,21 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
@@ -4038,9 +4123,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.49"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4051,9 +4136,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4061,9 +4146,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4074,9 +4159,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasm-streams"
@@ -4093,9 +4181,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ serde = { version = "1.0.217", optional = true }
 factrs-typetag = { version = "0.2.0", optional = true, path = "./factrs-typetag" }
 
 # rerun support
-rerun = { version = "0.21.0", optional = true, default-features = false, features = [
+rerun = { version = "0.22", optional = true, default-features = false, features = [
     "sdk",
 ] }
 

--- a/examples/g2o.rs
+++ b/examples/g2o.rs
@@ -18,9 +18,14 @@ use rerun::{Arrows2D, Arrows3D, Points2D, Points3D};
 fn rerun_init(opt: &mut GaussNewton, dim: &str, obj: &str) {
     // Setup the rerun & the callback
     let socket = SocketAddrV4::new("0.0.0.0".parse().unwrap(), 9876);
-    let rec = rerun::RecordingStreamBuilder::new("rerun_example_dna_abacus")
+    let rec = rerun::RecordingStreamBuilder::new("factrs-g2o-example")
         .connect_tcp_opts(SocketAddr::V4(socket), rerun::default_flush_timeout())
         .unwrap();
+
+    // Log the graph
+    let (nodes, edges) = opt.graph().into();
+    rec.log_static("graph", &[&nodes as &dyn rerun::AsComponents, &edges])
+        .expect("log failed");
 
     let topic = "base/solution";
 

--- a/src/containers/graph.rs
+++ b/src/containers/graph.rs
@@ -105,6 +105,10 @@ impl Graph {
             sparsity_order,
         }
     }
+
+    pub fn iter(&self) -> std::slice::Iter<Factor> {
+        self.factors.iter()
+    }
 }
 
 impl Debug for Graph {
@@ -113,12 +117,21 @@ impl Debug for Graph {
     }
 }
 
+impl IntoIterator for Graph {
+    type Item = Factor;
+    type IntoIter = std::vec::IntoIter<Factor>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.factors.into_iter()
+    }
+}
+
 /// Formatter for a graph
 ///
 /// Specifically, this can be used if custom symbols are desired. See
 /// [tests/custom_key](https://github.com/rpl-cmu/factrs/blob/dev/tests/custom_key.rs) for examples.
 pub struct GraphFormatter<'g, KF> {
-    graph: &'g Graph,
+    pub graph: &'g Graph,
     kf: PhantomData<KF>,
 }
 

--- a/src/rerun.rs
+++ b/src/rerun.rs
@@ -1,10 +1,12 @@
+use std::collections::HashSet;
+
 use rerun::{
-    components::RotationQuat, Arrows2D, Arrows3D, AsComponents, Points2D, Points3D, Quaternion,
-    Rotation3D, Transform3D, Vec2D, Vec3D,
+    components::RotationQuat, Arrows2D, Arrows3D, AsComponents, GraphEdges, GraphNodes, Points2D,
+    Points3D, Quaternion, Rotation3D, Transform3D, Vec2D, Vec3D,
 };
 
 use crate::{
-    containers::Values,
+    containers::{DefaultSymbolHandler, Graph, GraphFormatter, KeyFormatter, Values},
     optimizers::OptObserver,
     variables::{MatrixLieGroup, VariableDtype, VectorVar2, VectorVar3, SE2, SE3, SO2, SO3},
 };
@@ -273,18 +275,27 @@ impl<'a> FromIterator<&'a SE2> for Arrows2D {
         let mut colors = Vec::new();
 
         for se2 in iter {
-            let this: Arrows2D = se2.into();
-            vectors.extend_from_slice(&this.vectors);
-            origins.extend_from_slice(
-                &this
-                    .origins
-                    .expect("SE2 missing origins in conversion to rerun::Arrows2D"),
-            );
-            colors.extend_from_slice(
-                &this
-                    .colors
-                    .expect("SE2 missing colors in conversion to rerun::Arrows2D"),
-            );
+            let mat = se2.rot().to_matrix().map(|x| x as f32);
+            let vec_x: [f32; 2] = mat
+                .column(0)
+                .as_slice()
+                .try_into()
+                .expect("Failed to convert to slice");
+            let vec_y: [f32; 2] = mat
+                .column(1)
+                .as_slice()
+                .try_into()
+                .expect("Failed to convert to slice");
+
+            let pos = [se2.x() as f32, se2.y() as f32];
+            let pos = Vec2D::new(pos[0], pos[1]);
+
+            vectors.push(vec_x);
+            vectors.push(vec_y);
+            origins.push(pos);
+            origins.push(pos);
+            colors.push([255, 0, 0]);
+            colors.push([0, 255, 0]);
         }
 
         Arrows2D::from_vectors(vectors)
@@ -327,18 +338,34 @@ impl<'a> FromIterator<&'a SE3> for Arrows3D {
         let mut colors = Vec::new();
 
         for se3 in iter {
-            let this: Arrows3D = se3.into();
-            vectors.extend_from_slice(&this.vectors);
-            origins.extend_from_slice(
-                &this
-                    .origins
-                    .expect("SE3 missing origins in conversion to rerun::Arrows3D"),
-            );
-            colors.extend_from_slice(
-                &this
-                    .colors
-                    .expect("SE3 missing colors in conversion to rerun::Arrows3D"),
-            );
+            let mat = se3.rot().to_matrix().map(|x| x as f32);
+            let vec_x: [f32; 3] = mat
+                .column(0)
+                .as_slice()
+                .try_into()
+                .expect("Failed to convert to slice");
+            let vec_y: [f32; 3] = mat
+                .column(1)
+                .as_slice()
+                .try_into()
+                .expect("Failed to convert to slice");
+            let vec_z: [f32; 3] = mat
+                .column(2)
+                .as_slice()
+                .try_into()
+                .expect("Failed to convert to slice");
+            let pos: VectorVar3 = se3.xyz().clone_owned().into();
+            let pos: Vec3D = pos.into();
+
+            vectors.push(vec_x);
+            vectors.push(vec_y);
+            vectors.push(vec_z);
+            origins.push(pos);
+            origins.push(pos);
+            origins.push(pos);
+            colors.push([255, 0, 0]);
+            colors.push([0, 255, 0]);
+            colors.push([0, 0, 255]);
         }
 
         Arrows3D::from_vectors(vectors)
@@ -357,6 +384,71 @@ impl<'a> FromIterator<&'a SE3> for Points3D {
         }
 
         Points3D::new(points)
+    }
+}
+
+// ------------------------- Graph ------------------------- //
+impl<'g, KF: KeyFormatter> From<&GraphFormatter<'g, KF>> for (GraphNodes, GraphEdges) {
+    fn from(graph: &GraphFormatter<'g, KF>) -> (GraphNodes, GraphEdges) {
+        let g = graph.graph;
+
+        // Get all keys and their names
+        let keys_raw = g
+            .iter()
+            .flat_map(|f| f.keys())
+            .copied()
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect::<Vec<_>>();
+        let key_names = keys_raw
+            .iter()
+            .map(|k| {
+                let mut s = String::new();
+                KF::fmt(&mut s, *k).expect("Failed to write to string");
+                s
+            })
+            .collect::<Vec<_>>();
+        let keys = keys_raw.into_iter().map(|k| format!("{}", k.0));
+
+        // Not sure if this is officially supported, but missing nodes leads to dots for
+        // nodes
+        // So we purposefully don't put nodes into the graph for the factors
+        // let nodes = (0..g.len()).map(|x| format!("factor{}", x)).chain(keys);
+        // let labels = (0..g.len()).map(|_| String::new()).chain(key_names);
+        let nodes = keys;
+        let labels = key_names;
+        let nodes = GraphNodes::new(nodes).with_labels(labels);
+
+        // Get all edges
+        let mut edges = Vec::new();
+        for (i, f) in g.iter().enumerate() {
+            for k in f.keys() {
+                edges.push((format!("{}", k.0), format!("factor{}", i)));
+            }
+        }
+        let edges = GraphEdges::new(edges);
+
+        (nodes, edges)
+    }
+}
+
+impl<'g, KF: KeyFormatter> From<GraphFormatter<'g, KF>> for (GraphNodes, GraphEdges) {
+    fn from(graph: GraphFormatter<'g, KF>) -> (GraphNodes, GraphEdges) {
+        (&graph).into()
+    }
+}
+
+impl From<&Graph> for (GraphNodes, GraphEdges) {
+    fn from(graph: &Graph) -> (GraphNodes, GraphEdges) {
+        let formatter = GraphFormatter::<DefaultSymbolHandler>::new(graph);
+        (&formatter).into()
+    }
+}
+
+impl From<Graph> for (GraphNodes, GraphEdges) {
+    fn from(graph: Graph) -> (GraphNodes, GraphEdges) {
+        let formatter = GraphFormatter::<DefaultSymbolHandler>::new(&graph);
+        (&formatter).into()
     }
 }
 


### PR DESCRIPTION
Adds an `From` implementation to convert from `factrs::Graph` to the new [rerun graph](https://rerun.io/examples/feature-showcase/graphs) visualizer!

Not super informative for large scale pose graphs, but should be a good debugging tool for smaller graphs. Maybe I'll add some heuristics using location later - ie use XY position for location in the graph, or something along those lines.

Also bumps the rerun version, and makes a few tweaks to fix some changes related to it.
![graph-close](https://github.com/user-attachments/assets/a05b2730-11de-4dda-b562-2f59191d631e)
![graph-far](https://github.com/user-attachments/assets/56763bd3-8639-40ec-9353-403ff39759ca)
